### PR TITLE
Add Levantine v1.0.0

### DIFF
--- a/exts/levantine.json
+++ b/exts/levantine.json
@@ -1,0 +1,6 @@
+{
+  "repository": "https://github.com/floppydiskette/moonlight-exts.git",
+  "commit": "697d764e8e24c6a7914c371de48be81de474be7d",
+  "scripts": ["build", "repo"],
+  "artifact": "repo/levantine.asar"
+}

--- a/exts/levantine.json
+++ b/exts/levantine.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/floppydiskette/moonlight-exts.git",
-  "commit": "697d764e8e24c6a7914c371de48be81de474be7d",
+  "commit": "6633317881a0d21352c91876a4153708af7351a9",
   "scripts": ["build", "repo"],
   "artifact": "repo/levantine.asar"
 }


### PR DESCRIPTION
Levantine is an extension which obfuscates all messages into a format only readable by the viewer in order to prevent shoulder surfing while viewing Discord in public.

By default, the extension converts all text into a pseudo-Japanese format, however a custom "mappings file" can be provided which allows for different types of output.

![image](https://github.com/user-attachments/assets/41531c62-f7fa-4386-b703-ef34ed55edbf)
