### PR TITLE
fix katex regex runtime

### DIFF
--- a/exts/katex.json
+++ b/exts/katex.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/s5bug/aly-extensions.git",
-  "commit": "72426fcebbcb7f3ca1912e687fa735c2946d1217",
+  "commit": "a5b94770a2715a6d02abd2e3dee1b60b2fb48355",
   "scripts": ["build", "repo"],
   "artifact": "repo/katex.asar"
 }

--- a/exts/katex.json
+++ b/exts/katex.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/s5bug/aly-extensions.git",
-  "commit": "a5b94770a2715a6d02abd2e3dee1b60b2fb48355",
+  "commit": "72c31968d368f8d320569f04fd6f6d4eb121c774",
   "scripts": ["build", "repo"],
   "artifact": "repo/katex.asar"
 }


### PR DESCRIPTION
Makes it so that the regex for the KaTeX plugin has a runtime of O(n) rather than O(n²), because for some reason JS RegExp couldn't see that optimization

This prevents the slate editor from stalling for up to hundreds of frames on large inputs