### PR TITLE
Add Remind Me

### DIFF
--- a/exts/remind-me.json
+++ b/exts/remind-me.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/karashiiro/moonlight-extensions.git",
-  "commit": "6711596f86a97f0432169c7e5c39ca72f254b22a",
+  "commit": "26e1cdd231b4c4d145bd6df0317e55b0f15aad89",
   "scripts": ["build", "repo"],
   "artifact": "repo/remind-me.asar"
 }

--- a/exts/remind-me.json
+++ b/exts/remind-me.json
@@ -1,0 +1,6 @@
+{
+  "repository": "https://github.com/karashiiro/moonlight-extensions.git",
+  "commit": "6711596f86a97f0432169c7e5c39ca72f254b22a",
+  "scripts": ["build", "repo"],
+  "artifact": "repo/remind-me.asar"
+}


### PR DESCRIPTION
Remind Me enables these Discord experimental tabs in the Inbox and makes them work locally by patching in a client-side store for them:

![image](https://github.com/user-attachments/assets/35eb57d2-ea36-4b52-a57b-280779fd9955)

The real endpoints 404 if you aren't in the corresponding feature rollout.

I have heard of one singular person being in the feature rollout for bookmarks (`2024-06_message_bookmarks`) - and none for reminders (`2022-08_message_todos_staff_only`), so I'm pretty sure this will have at least a good several months of longevity to it.

---

**API Interactions**

- Removed: ~~Fetching messages (cached): [source](https://github.com/karashiiro/moonlight-extensions/blob/53eed4613c7ff79318e4c86b7bee32a72053b019/src/remind-me/webpackModules/savedMessagesShim.ts#L91-L127)~~