### PR TITLE
Add No Notification Sound Except DMs

### DIFF
--- a/exts/noNotificationSoundExceptDms.json
+++ b/exts/noNotificationSoundExceptDms.json
@@ -1,0 +1,6 @@
+{
+  "repository": "https://github.com/uwx/moonlight-extensions.git",
+  "commit": "d9f5d5e40cc2720aad9144caf3af9e945ee4b814",
+  "scripts": ["build", "repo"],
+  "artifact": "repo/noNotificationSoundExceptDms.asar"
+}


### PR DESCRIPTION
Adds a plugin that mutes notification sounds except in DMs.