### PR TITLE
Create memberCount.json

### DIFF
--- a/exts/memberCount.json
+++ b/exts/memberCount.json
@@ -1,0 +1,6 @@
+{
+  "repository": "https://github.com/TheKodeToad/moonlight-extensions",
+  "commit": "61a638e9e8e66e72a5bcf41d4535988e4e699fb3",
+  "scripts": ["build", "repo"],
+  "artifact": "repo/memberCount.asar"
+}                  


### PR DESCRIPTION
Currently it is quite limited: there's no server tooltip count, no channel specific online count, and data does not appear unless you have the member list enabled and visit a text/news channel. I'm not sure if automatically fetching it would count as automation, but I mainly did not implement it because I tried and it did not work properly!