### PR TITLE
Create Send Timestamps

### DIFF
--- a/exts/sendTimestamps.json
+++ b/exts/sendTimestamps.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/uwx/moonlight-extensions.git",
-  "commit": "0f537428dde8732bb9f2a902b71a41cb63f86710",
+  "commit": "c82bc4552e6855ff8b87a3a295be151509589214",
   "scripts": ["build", "repo"],
   "artifact": "repo/sendTimestamps.asar"
 }

--- a/exts/sendTimestamps.json
+++ b/exts/sendTimestamps.json
@@ -1,0 +1,6 @@
+{
+  "repository": "https://github.com/uwx/moonlight-extensions.git",
+  "commit": "0f537428dde8732bb9f2a902b71a41cb63f86710",
+  "scripts": ["build", "repo"],
+  "artifact": "repo/sendTimestamps.asar"
+}


### PR DESCRIPTION
Adds a .time command to send timestamps written in natural language.
For instance: `.send tomorrow at 2pm` will send a message with a timestamp pointing to "tomorrow at 2pm" local time.

To send in alternative formats, use one of: `.timeshortdate`, `.timelongdate`, `.timelongdateshorttime`, `.timefull`, `.timeshorttime`, `.timelongtime`, `.timerelative`. Defaults to `.timerelative`.

Powered by [Microsoft.Recognizers.Text](https://github.com/microsoft/Recognizers-Text).