### PR TITLE
Add onePingPerDM

### DIFF
--- a/exts/onePingPerDM.json
+++ b/exts/onePingPerDM.json
@@ -1,0 +1,6 @@
+{
+  "repository": "https://github.com/MeguminSama/moonlight-extensions.git",
+  "commit": "228f75cc2a4ba1a70efaf4098918a44be26f2c24",
+  "scripts": ["build", "repo"],
+  "artifact": "repo/onePingPerDM.asar"
+}


### PR DESCRIPTION
Really wanted to port over this plugin, so here it is!

Normally when someone DMs you multiple times, *ping ping ping ping* ***EXPLODES***

With this plugin, you only receive a ping for the first DM (until you read the channel). There are settings to allow `@everyone/@here` (in group chats) and `@mentions` to bypass the ping restrictions.

You can also pick whether to apply it to User DMs, Group Chats, or both.