### PR TITLE
update levantine to v1.0.2

### DIFF
--- a/exts/levantine.json
+++ b/exts/levantine.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/floppydiskette/moonlight-exts.git",
-  "commit": "6633317881a0d21352c91876a4153708af7351a9",
+  "commit": "75abc45ccc50e13a03d303c66a8c88ee212373eb",
   "scripts": ["build", "repo"],
   "artifact": "repo/levantine.asar"
 }


### PR DESCRIPTION
this levantine update fixes a bug when attempting to enable levantine without setting a mappings path. the fix should prevent looping loading screens and instead now load a default mappings path (which was the previously intended behavior)

commit with fixes can be seen here
https://github.com/floppydiskette/moonlight-exts/commit/7de62579608f4a9d65149ed55110d91f83033b02

however, the commit i'm using is the one after it
https://github.com/floppydiskette/moonlight-exts/commit/75abc45ccc50e13a03d303c66a8c88ee212373eb

this is because i had to update my deploy.yml to the new one for it to work properly