### PR TITLE
Add whosWatching extension

### DIFF
--- a/exts/whosWatching.json
+++ b/exts/whosWatching.json
@@ -1,0 +1,4 @@
+{
+  "repository": "https://github.com/Enovale/moonlight-extensions.git",
+  "commit": "89ef84892fb459d475f8ed6d23b38f1abaf5c37d"
+}


### PR DESCRIPTION
Added a port of [this extension](https://github.com/fres621/vencord-whos-watching) by fres.
Slightly updated to also have a tooltip cause it always bothered me.

I hope this does not violate the privacy rule of the repository guidelines, as this information is already readily available to the user, it's just cumbersome to access.