### PR TITLE
Create manyAccounts.json

### DIFF
--- a/exts/manyAccounts.json
+++ b/exts/manyAccounts.json
@@ -1,4 +1,4 @@
 {
   "repository": "https://github.com/ap-1/many-accounts.git",
-  "commit": "cda17f1e39ef25fa23f9d59300c0bb892a522f77"
+  "commit": "bffebfdfd44caffc826659705ddb0ea22fb5b222"
 }

--- a/exts/manyAccounts.json
+++ b/exts/manyAccounts.json
@@ -1,4 +1,4 @@
 {
   "repository": "https://github.com/ap-1/many-accounts.git",
-  "commit": "bffebfdfd44caffc826659705ddb0ea22fb5b222"
+  "commit": "5b80f0932414bc9b81c0a8e14106127946b6e245"
 }

--- a/exts/manyAccounts.json
+++ b/exts/manyAccounts.json
@@ -1,0 +1,4 @@
+{
+  "repository": "https://github.com/ap-1/many-accounts.git",
+  "commit": "cda17f1e39ef25fa23f9d59300c0bb892a522f77"
+}


### PR DESCRIPTION
A simple patch that removes Discord's arbitrary limit of adding 5 accounts to the built-in account switcher.

The main use case is for individuals who participate in multiple communities at once, and would like to isolate their identity across them.

Hopefully it's also a suitable replacement for having to buy Nitro before making per-server profiles.