### PR TITLE
Add noNitroUpsell

### DIFF
--- a/exts/noNitroUpsell.json
+++ b/exts/noNitroUpsell.json
@@ -1,0 +1,6 @@
+{
+  "repository": "https://github.com/Enovale/moonlight-extensions.git",
+  "commit": "781cf086268926f660a6457ea1df2983151ab57f",
+  "scripts": ["build", "repo"],
+  "artifact": "repo/noNitroUpsell.asar"
+}


### PR DESCRIPTION
Forces the UserStore's `premiumUser` to always be true, thus removing nitro popups and upsells throughout the app. I marked it Danger Zone as some aspects of the app obviously behave unexpectedly with this patch.

- Nitro Gifts will appear to be redeemable but just error when you attempt to.
- Soundboard sounds that you should not have access to will appear as usable, and appear to play, but they cannot be heard by others.