### PR TITLE
typingTweaks 1.0.4->1.0.5

### DIFF
--- a/exts/typingTweaks.json
+++ b/exts/typingTweaks.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/Enovale/moonlight-extensions.git",
-  "commit": "a759635058328cfb9e27048cc4b5fac5019baf3d",
+  "commit": "d5c8eed6d22f73e45161580102e37331787d4f5d",
   "scripts": ["build", "repo"],
   "artifact": "repo/typingTweaks.asar"
 }


### PR DESCRIPTION
Removed the extra style export, which not only created a duplicate style tag, but something about how I was exporting it was causing the extra style to just be `[object Object]` anyway.