### PR TITLE
Add streamQualityWorkaround

### DIFF
--- a/exts/streamQualityWorkaround.json
+++ b/exts/streamQualityWorkaround.json
@@ -1,0 +1,6 @@
+{
+  "repository": "https://github.com/Enovale/moonlight-extensions.git",
+  "commit": "c41e6b157dc814967fc25a013efc91a7124d5d5c",
+  "scripts": ["build", "repo"],
+  "artifact": "repo/streamQualityWorkaround.asar"
+}


### PR DESCRIPTION
Biggest thing to note is that this plugin adds an extra button to the actions of a screenshare, and if my understanding of the code is right, the button probably doesn't appear on windows when you're streaming a properly recognized activity or game.