### PR TITLE
add new notificationLib extension

### DIFF
--- a/exts/notificationLib.json
+++ b/exts/notificationLib.json
@@ -1,0 +1,6 @@
+{
+  "repository": "https://git.slonk.ing/slonk/moonlight-extensions",
+  "commit": "1af7337a20b42792d4399a4cb06e2d63aef394e1",
+  "scripts": ["build", "repo"],
+  "artifact": "repo/notificationLib.asar"
+}


### PR DESCRIPTION
for allowing multiple extensions to modify notifications without clashing with each other, and with explicit priorities

currently used by:

- Notification Content 2.0.0 (unpublished, waiting on this PR)
- @musicalartist12's upcoming extension