### PR TITLE
removeTopBar 1.0.3 -> 1.0.4

### DIFF
--- a/exts/removeTopBar.json
+++ b/exts/removeTopBar.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/Enovale/moonlight-extensions.git",
-  "commit": "d5c8eed6d22f73e45161580102e37331787d4f5d",
+  "commit": "b13ba02eee552cb87fd391e665c20295899b124c",
   "scripts": ["build", "repo"],
   "artifact": "repo/removeTopBar.asar"
 }


### PR DESCRIPTION
Fixes a patch that broke with a Discord updates, and makes the extension fail gracefully in case this happens again.