### PR TITLE
Update katex and ruby

### DIFF
--- a/exts/katex.json
+++ b/exts/katex.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/s5bug/aly-extensions.git",
-  "commit": "7644e76aa1ab2fe4f197b69275f0220f36fed128",
+  "commit": "e676ec1220eee3e6adcc413532a9aeeb39567d23",
   "scripts": ["build", "repo"],
   "artifact": "repo/katex.asar"
 }

--- a/exts/ruby.json
+++ b/exts/ruby.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/s5bug/aly-extensions.git",
-  "commit": "b97abc07fa8a62ff7e6d99383baf35d3815c910c",
+  "commit": "e676ec1220eee3e6adcc413532a9aeeb39567d23",
   "scripts": ["build", "repo"],
   "artifact": "repo/ruby.asar"
 }


### PR DESCRIPTION
A few general updates to the repository itself & fixes an issue in Ruby where `{{v,e,c,t,o,r,s},{a,n,d},{m,a,t,r,i,c,e,s}}` were causing a client freeze