### PR TITLE
All Activities 1.1.1

### DIFF
--- a/exts/allActivities.json
+++ b/exts/allActivities.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/Cynosphere/moonlight-extensions.git",
-  "commit": "44e762ec6ec0195a50ac8ad0645b25e8ab1b24cb",
+  "commit": "ef47ed6270f11d737f14b9f7e28a178bf25d24a3",
   "scripts": ["build", "repo"],
   "artifact": "repo/allActivities.asar"
 }


### PR DESCRIPTION
I genuinely wish ill will to the developer on the activities team that decided that it was a good idea to filter out Playing activity types to only show AND SEND one (1) Playing activity. I do not know how in a million years your commit in discord/discord was ever approved and merged and I hope it gets reverted and you get fired for this blunder. Especially when they don't even offer a new activity type for non-games.