### PR TITLE
Add clientSpoof extension

### DIFF
--- a/exts/clientSpoof.json
+++ b/exts/clientSpoof.json
@@ -1,0 +1,6 @@
+{
+    "repository": "https://github.com/krvntzkl/discord-client-spoof.git",
+    "commit": "6692be5ef574e04716355e9120141755545015b1",
+    "scripts": ["build", "repo"],
+    "artifact": "repo/clientSpoof.asar"
+}


### PR DESCRIPTION
Adds **Client Spoof** (`clientSpoof`) to the extension index.

**What it does:** Moonlight extension that adjusts Discord client super-properties so the visible client type (desktop / mobile / web, etc.) can differ from the real client, while keeping real `client_build_number` values. Useful for privacy vs platform-indicator style plugins.

**Source:** https://github.com/krvntzkl/discord-client-spoof  
**Manifest id:** `clientSpoof` (matches `exts/clientSpoof.json`)

**Build:** `pnpm` with scripts `build` + `repo`, artifact `repo/clientSpoof.asar` as per [official contributing docs](https://moonlight-mod.github.io/ext-dev/official-repository/).

**Commit pinned:** `6692be5ef574e04716355e9120141755545015b1`

---

Let me know if you want the commit hash or version bumped before merge.